### PR TITLE
Change spotlight selection

### DIFF
--- a/Assets/Prefabs/StageSelection.prefab
+++ b/Assets/Prefabs/StageSelection.prefab
@@ -1,5 +1,137 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2861200451730477070
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6310203082085530566}
+  - component: {fileID: 4595865555175913929}
+  - component: {fileID: 2171740570715053251}
+  - component: {fileID: 7807815786110417828}
+  m_Layer: 5
+  m_Name: MoveSelection_Right
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6310203082085530566
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2861200451730477070}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4054528096602876343}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: -26.65, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4595865555175913929
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2861200451730477070}
+  m_CullTransparentMesh: 1
+--- !u!114 &2171740570715053251
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2861200451730477070}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10915, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7807815786110417828
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2861200451730477070}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2171740570715053251}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1183901214132014878}
+        m_TargetAssemblyTypeName: StageSelection, Assembly-CSharp
+        m_MethodName: MoveCurrentSelectionRight
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &3594355216830444843
 GameObject:
   m_ObjectHideFlags: 0
@@ -33,11 +165,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 4054528096602876343}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -211.2, y: 0.3}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 36.2, y: 48.1}
   m_SizeDelta: {x: 60, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 0}
 --- !u!222 &4867374912987426694
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -160,15 +292,15 @@ RectTransform:
   m_GameObject: {fileID: 6254957441978281464}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.96, y: 0.96, z: 0.96}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 4054528096602876343}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -61.5}
-  m_SizeDelta: {x: 60, y: 60}
+  m_AnchoredPosition: {x: 0, y: -156}
+  m_SizeDelta: {x: 60, y: 60.000015}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4060606091609764775
 CanvasRenderer:
@@ -254,7 +386,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1183901214132014878}
         m_TargetAssemblyTypeName: StageSelection, Assembly-CSharp
-        m_MethodName: SwapCarousels
+        m_MethodName: HideStageSelection
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -293,11 +425,12 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 7193798427326968853}
   - {fileID: 919057310550137628}
   - {fileID: 4060820449391604415}
   - {fileID: 4125978880717206221}
   - {fileID: 4736090607802862064}
+  - {fileID: 911190442496234349}
+  - {fileID: 6310203082085530566}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -323,7 +456,7 @@ MonoBehaviour:
   swapperImage: {fileID: 5725330614001453346}
   musicianImage: {fileID: 21300000, guid: 08ed04d133f500d43bcf5f5e14557326, type: 3}
   instrumentImage: {fileID: 21300000, guid: 54eba24200ffb90469061eced2665a67, type: 3}
---- !u!1 &9065058131480184588
+--- !u!1 &8764059516730558105
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -331,66 +464,66 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7193798427326968853}
-  - component: {fileID: 3979204764566226090}
-  - component: {fileID: 6887480224355115006}
-  - component: {fileID: 4193971482325225327}
+  - component: {fileID: 911190442496234349}
+  - component: {fileID: 5723399516637700467}
+  - component: {fileID: 9061843550439109916}
+  - component: {fileID: 2960012874719393518}
   m_Layer: 5
-  m_Name: Panel
+  m_Name: MoveSelection_Left
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &7193798427326968853
+--- !u!224 &911190442496234349
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9065058131480184588}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_GameObject: {fileID: 8764059516730558105}
+  m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4054528096602876343}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 10000, y: 10000}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -90}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 26.65, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &3979204764566226090
+--- !u!222 &5723399516637700467
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9065058131480184588}
+  m_GameObject: {fileID: 8764059516730558105}
   m_CullTransparentMesh: 1
---- !u!114 &6887480224355115006
+--- !u!114 &9061843550439109916
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9065058131480184588}
+  m_GameObject: {fileID: 8764059516730558105}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
+  m_Sprite: {fileID: 10915, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -399,35 +532,62 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &4193971482325225327
+--- !u!114 &2960012874719393518
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9065058131480184588}
+  m_GameObject: {fileID: 8764059516730558105}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Delegates:
-  - eventID: 2
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 1183901214132014878}
-          m_TargetAssemblyTypeName: StageSelection, Assembly-CSharp
-          m_MethodName: HideStageSelection
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 2
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 9061843550439109916}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1183901214132014878}
+        m_TargetAssemblyTypeName: StageSelection, Assembly-CSharp
+        m_MethodName: MoveCurrentSelectionLeft
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1001 &505044226726556912
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -478,27 +638,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4564584738261894735, guid: 4d41746c7d43f324b83b6f96978f6996, type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0.4
       objectReference: {fileID: 0}
     - target: {fileID: 4564584738261894735, guid: 4d41746c7d43f324b83b6f96978f6996, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0.6651004
       objectReference: {fileID: 0}
     - target: {fileID: 4564584738261894735, guid: 4d41746c7d43f324b83b6f96978f6996, type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 0.15542051
       objectReference: {fileID: 0}
     - target: {fileID: 4564584738261894735, guid: 4d41746c7d43f324b83b6f96978f6996, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.47000003
       objectReference: {fileID: 0}
     - target: {fileID: 4564584738261894735, guid: 4d41746c7d43f324b83b6f96978f6996, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: -0.0000026226044
       objectReference: {fileID: 0}
     - target: {fileID: 4564584738261894735, guid: 4d41746c7d43f324b83b6f96978f6996, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: -0.0000076293945
       objectReference: {fileID: 0}
     - target: {fileID: 4564584738261894735, guid: 4d41746c7d43f324b83b6f96978f6996, type: 3}
       propertyPath: m_LocalPosition.x
@@ -534,7 +694,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4564584738261894735, guid: 4d41746c7d43f324b83b6f96978f6996, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -0.0000038146973
       objectReference: {fileID: 0}
     - target: {fileID: 4564584738261894735, guid: 4d41746c7d43f324b83b6f96978f6996, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -598,7 +758,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7960726648700089362, guid: 4d41746c7d43f324b83b6f96978f6996, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: -195.6635
       objectReference: {fileID: 0}
     - target: {fileID: 8423187041693405939, guid: 4d41746c7d43f324b83b6f96978f6996, type: 3}
       propertyPath: m_Name
@@ -679,19 +839,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 43857795649081813, guid: 44edaaa7416b3784397905df0663bf4c, type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0.4
       objectReference: {fileID: 0}
     - target: {fileID: 43857795649081813, guid: 44edaaa7416b3784397905df0663bf4c, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0.3
       objectReference: {fileID: 0}
     - target: {fileID: 43857795649081813, guid: 44edaaa7416b3784397905df0663bf4c, type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 0.15
       objectReference: {fileID: 0}
     - target: {fileID: 43857795649081813, guid: 44edaaa7416b3784397905df0663bf4c, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.1
       objectReference: {fileID: 0}
     - target: {fileID: 43857795649081813, guid: 44edaaa7416b3784397905df0663bf4c, type: 3}
       propertyPath: m_SizeDelta.x
@@ -823,7 +983,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5888834168268235656, guid: 44edaaa7416b3784397905df0663bf4c, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: -200
       objectReference: {fileID: 0}
     - target: {fileID: 6466655538887317989, guid: 44edaaa7416b3784397905df0663bf4c, type: 3}
       propertyPath: m_AnchorMax.y

--- a/Assets/Prefabs/UI/ChapterCanvas.prefab
+++ b/Assets/Prefabs/UI/ChapterCanvas.prefab
@@ -547,10 +547,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5653939750059239062}
     m_Modifications:
-    - target: {fileID: 3238287769622202723, guid: 3d0eb8c67d8c79f4bac9863792b546be, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: HideStageSelection
-      objectReference: {fileID: 0}
     - target: {fileID: 4054528096602876343, guid: 3d0eb8c67d8c79f4bac9863792b546be, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -561,27 +557,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4054528096602876343, guid: 3d0eb8c67d8c79f4bac9863792b546be, type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4054528096602876343, guid: 3d0eb8c67d8c79f4bac9863792b546be, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4054528096602876343, guid: 3d0eb8c67d8c79f4bac9863792b546be, type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4054528096602876343, guid: 3d0eb8c67d8c79f4bac9863792b546be, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4054528096602876343, guid: 3d0eb8c67d8c79f4bac9863792b546be, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 349.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4054528096602876343, guid: 3d0eb8c67d8c79f4bac9863792b546be, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 59.6
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4054528096602876343, guid: 3d0eb8c67d8c79f4bac9863792b546be, type: 3}
       propertyPath: m_LocalPosition.x
@@ -617,7 +613,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4054528096602876343, guid: 3d0eb8c67d8c79f4bac9863792b546be, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -96.6
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4054528096602876343, guid: 3d0eb8c67d8c79f4bac9863792b546be, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -629,6 +625,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4054528096602876343, guid: 3d0eb8c67d8c79f4bac9863792b546be, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4060820449391604415, guid: 3d0eb8c67d8c79f4bac9863792b546be, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6765430105869461825, guid: 3d0eb8c67d8c79f4bac9863792b546be, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7599940618506518754, guid: 3d0eb8c67d8c79f4bac9863792b546be, type: 3}
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8367674613500720179, guid: 3d0eb8c67d8c79f4bac9863792b546be, type: 3}
@@ -682,6 +690,22 @@ PrefabInstance:
       value: 52.87
       objectReference: {fileID: 0}
     - target: {fileID: 2346935520010119250, guid: 63bfddd536e14ba478f5473b6653c59a, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -50
+      objectReference: {fileID: 0}
+    - target: {fileID: 6168963320644098940, guid: 63bfddd536e14ba478f5473b6653c59a, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6168963320644098940, guid: 63bfddd536e14ba478f5473b6653c59a, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6168963320644098940, guid: 63bfddd536e14ba478f5473b6653c59a, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 88.11667
+      objectReference: {fileID: 0}
+    - target: {fileID: 6168963320644098940, guid: 63bfddd536e14ba478f5473b6653c59a, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}

--- a/Assets/Scenes/Act 1 Chapter 1.unity
+++ b/Assets/Scenes/Act 1 Chapter 1.unity
@@ -141,7 +141,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2571117010890321880, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.7800002
+      value: 2.9000003
       objectReference: {fileID: 0}
     - target: {fileID: 2571117010890321880, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
       propertyPath: m_LocalPosition.z
@@ -224,7 +224,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2571117010890321880, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.7800002
+      value: 2.9000003
       objectReference: {fileID: 0}
     - target: {fileID: 2571117010890321880, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
       propertyPath: m_LocalPosition.z
@@ -577,7 +577,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2571117010890321880, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.86
+      value: 2.98
       objectReference: {fileID: 0}
     - target: {fileID: 2571117010890321880, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
       propertyPath: m_LocalPosition.z
@@ -710,7 +710,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4558876264793420000, guid: 96c82c813d66c624691bf111568ff665, type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4707571682937795290, guid: 96c82c813d66c624691bf111568ff665, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target

--- a/Assets/Scenes/Act 1 Chapter 1.unity
+++ b/Assets/Scenes/Act 1 Chapter 1.unity
@@ -137,7 +137,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2571117010890321880, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 3.13
+      value: 0.6
       objectReference: {fileID: 0}
     - target: {fileID: 2571117010890321880, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
       propertyPath: m_LocalPosition.y
@@ -175,9 +175,96 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5387348405708187771, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      propertyPath: stagePositionNumber
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5715685956295416589, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
       propertyPath: m_Name
       value: StagePosition (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8375779289373324494, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      propertyPath: m_text
+      value: Instrument
+      objectReference: {fileID: 0}
+    - target: {fileID: 8496539554590621757, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      propertyPath: m_Delegates.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8496539554590621757, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 6594463408581026082, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 7498558361005084192, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+--- !u!1001 &604434030
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 118423123027634021, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      propertyPath: m_text
+      value: Musician
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571117010890321880, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.71
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571117010890321880, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.7800002
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571117010890321880, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571117010890321880, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571117010890321880, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571117010890321880, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571117010890321880, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571117010890321880, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571117010890321880, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571117010890321880, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5387348405708187771, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      propertyPath: stagePositionNumber
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5715685956295416589, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
+      propertyPath: m_Name
+      value: StagePosition (2)
       objectReference: {fileID: 0}
     - target: {fileID: 8375779289373324494, guid: 1f7385dcc7f227c45af6bdad86a4cd66, type: 3}
       propertyPath: m_text
@@ -593,6 +680,18 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
+    - target: {fileID: 1637111941475216786, guid: 96c82c813d66c624691bf111568ff665, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2074411410962743061, guid: 96c82c813d66c624691bf111568ff665, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -26.650024
+      objectReference: {fileID: 0}
+    - target: {fileID: 2460086678356739121, guid: 96c82c813d66c624691bf111568ff665, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2513851119371973600, guid: 96c82c813d66c624691bf111568ff665, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
@@ -609,10 +708,18 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
+    - target: {fileID: 4558876264793420000, guid: 96c82c813d66c624691bf111568ff665, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4707571682937795290, guid: 96c82c813d66c624691bf111568ff665, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 741236656}
+    - target: {fileID: 5187760378351916990, guid: 96c82c813d66c624691bf111568ff665, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 26.650024
+      objectReference: {fileID: 0}
     - target: {fileID: 5653939750059239062, guid: 96c82c813d66c624691bf111568ff665, type: 3}
       propertyPath: m_Pivot.x
       value: 0
@@ -697,9 +804,25 @@ PrefabInstance:
       propertyPath: chapter
       value: 
       objectReference: {fileID: 741236656}
+    - target: {fileID: 8221877040128898590, guid: 96c82c813d66c624691bf111568ff665, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 36.19995
+      objectReference: {fileID: 0}
+    - target: {fileID: 8221877040128898590, guid: 96c82c813d66c624691bf111568ff665, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 48.099976
+      objectReference: {fileID: 0}
     - target: {fileID: 8266991268395459404, guid: 96c82c813d66c624691bf111568ff665, type: 3}
       propertyPath: m_Name
       value: ChapterCanvas
+      objectReference: {fileID: 0}
+    - target: {fileID: 8287042072777324140, guid: 96c82c813d66c624691bf111568ff665, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8287042072777324140, guid: 96c82c813d66c624691bf111568ff665, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9206434770258691792, guid: 96c82c813d66c624691bf111568ff665, type: 3}
       propertyPath: m_AnchorMax.y
@@ -850,6 +973,7 @@ SceneRoots:
   - {fileID: 1706224979405155228}
   - {fileID: 4068860404493254140}
   - {fileID: 180008107}
+  - {fileID: 604434030}
   - {fileID: 8972571187030559120}
   - {fileID: 8286946921265692557}
   - {fileID: 789300825}

--- a/Assets/Scripts/GameStructure/ChapterUI.cs
+++ b/Assets/Scripts/GameStructure/ChapterUI.cs
@@ -54,6 +54,7 @@ public class ChapterUI : MonoBehaviour
         _chapter.onStageChanged += OnStageChanged;
         StagePosition.OnStagePositionClicked += OnStagePositionClicked;
         StagePosition.OnStagePositionChanged += OnStagePositionChanged;
+        StageSelection.OnStageSelectionFocusChanged += StagePositionFocusChanged;
         _chapter.onRevealRating += RevealRating;
     }
     
@@ -65,13 +66,14 @@ public class ChapterUI : MonoBehaviour
             _chapter.onStageChanged -= OnStageChanged;
         }
         
-        StagePosition.OnStagePositionClicked -= OnStagePositionClicked;
-        StagePosition.OnStagePositionChanged -= OnStagePositionChanged;
-
         if (onPointerPosition is not null)
         {
             onPointerPosition.performed -= OnPointerPosition;
         }
+        
+        StagePosition.OnStagePositionClicked -= OnStagePositionClicked;
+        StagePosition.OnStagePositionChanged -= OnStagePositionChanged;
+        StageSelection.OnStageSelectionFocusChanged -= StagePositionFocusChanged;
     }
 
     private void OnStageChanged(Chapter.ChapterStage chapterStage)
@@ -98,9 +100,22 @@ public class ChapterUI : MonoBehaviour
 
     private void OnStagePositionClicked(StagePosition clickedStagePosition)
     {
-        if (Chapter.Instance && Chapter.Instance.IsInCurrentStage(Chapter.ChapterStage.StageSelection))
+        bool inStageSelection = Chapter.Instance && Chapter.Instance.IsInCurrentStage(Chapter.ChapterStage.StageSelection);
+        bool canClickPosition = !StageSelection.Instance.HasActiveSelection();
+        if (inStageSelection && canClickPosition)
         {
-            _SelectionCarousels.ShowStageSelection(clickedStagePosition);
+            StagePositionFocusChanged(clickedStagePosition);
+        }
+    }
+
+    private void StagePositionFocusChanged(StagePosition newFocusStagePosition)
+    {
+        _SelectionCarousels.ShowStageSelection(newFocusStagePosition);
+            
+        StsCamera stsCamera = StsCamera.Instance;
+        if (stsCamera)
+        {
+            stsCamera.OnStagePositionClicked(newFocusStagePosition);
         }
     }
     private void OnStagePositionChanged(StagePosition changedStagePosition)

--- a/Assets/Scripts/GameStructure/ChapterUI.cs
+++ b/Assets/Scripts/GameStructure/ChapterUI.cs
@@ -59,12 +59,19 @@ public class ChapterUI : MonoBehaviour
     
     private void OnDisable()
     {
-        _chapter.onStageChanged -= OnStageChanged;
+        if (_chapter is not null)
+        {
+            _chapter.onRevealRating -= RevealRating;
+            _chapter.onStageChanged -= OnStageChanged;
+        }
+        
         StagePosition.OnStagePositionClicked -= OnStagePositionClicked;
         StagePosition.OnStagePositionChanged -= OnStagePositionChanged;
-        _chapter.onRevealRating -= RevealRating;
-        
-        onPointerPosition.performed -= OnPointerPosition;
+
+        if (onPointerPosition is not null)
+        {
+            onPointerPosition.performed -= OnPointerPosition;
+        }
     }
 
     private void OnStageChanged(Chapter.ChapterStage chapterStage)

--- a/Assets/Scripts/UI/CoreGameplay/Stage/StagePosition.cs
+++ b/Assets/Scripts/UI/CoreGameplay/Stage/StagePosition.cs
@@ -28,10 +28,7 @@ public class StagePosition : MonoBehaviour
 
     public void OnInteract()
     {
-        if (Chapter.Instance && Chapter.Instance.IsInCurrentStage(Chapter.ChapterStage.StageSelection))
-        {
-            OnStagePositionClicked?.Invoke(this);
-        }
+        OnStagePositionClicked?.Invoke(this);
     }
 
     public void MusicianSelectionChanged(Musician selection)

--- a/Assets/Scripts/UI/CoreGameplay/Stage/StageSelection.cs
+++ b/Assets/Scripts/UI/CoreGameplay/Stage/StageSelection.cs
@@ -21,7 +21,8 @@ public class StageSelection : Singleton<StageSelection>
     private List<StagePosition> _StagePositions = new List<StagePosition>();
 
     public static event Action OnStageSelectionStarted; 
-    public static event Action OnStageSelectionEnded; 
+    public static event Action OnStageSelectionEnded;
+    public static event Action<StagePosition> OnStageSelectionFocusChanged; 
 
     protected override void Awake()
     {
@@ -31,6 +32,7 @@ public class StageSelection : Singleton<StageSelection>
         {
             StSDebug.LogWarning($"{gameObject.name}: No Stage Positions found.");
         }
+        gameObject.SetActive(false);
     }
 
     private void Start()
@@ -146,12 +148,16 @@ public class StageSelection : Singleton<StageSelection>
         StagePosition newPos = _StagePositions.Find(position => position.stagePositionNumber == currentIndex);
         if (newPos)
         {
-            newPos.OnInteract();
+            OnStageSelectionFocusChanged?.Invoke(newPos);
         }
         else
         {
             StSDebug.LogError($"StageSelection: Could not find stage position with the index '{currentIndex}'");
         }
-        
+    }
+
+    public bool HasActiveSelection()
+    {
+        return activeStagePosition is not null;
     }
 }

--- a/Assets/Scripts/UI/CoreGameplay/Stage/StageSelection.cs
+++ b/Assets/Scripts/UI/CoreGameplay/Stage/StageSelection.cs
@@ -8,15 +8,9 @@ using Utils;
 
 public class StageSelection : Singleton<StageSelection>
 {
-    [SerializeField] private Carousel.CarouselType currentShowingCarousel = Carousel.CarouselType.Musician;
     public Carousel instrumentCarousel;
     public Carousel musicianCarousel;
     private StagePosition activeStagePosition = null;
-
-    [Header("Carousel Swapper")] 
-    [SerializeField] private Image swapperImage;
-    [SerializeField] private Sprite musicianImage;
-    [SerializeField] private Sprite instrumentImage;
 
     private List<StagePosition> _StagePositions = new List<StagePosition>();
 
@@ -35,32 +29,12 @@ public class StageSelection : Singleton<StageSelection>
         gameObject.SetActive(false);
     }
 
-    private void Start()
-    {
-        switch (currentShowingCarousel)
-        {
-            case Carousel.CarouselType.Musician:
-                swapperImage.sprite = musicianImage;
-                break;
-            case Carousel.CarouselType.Instrument:
-                swapperImage.sprite = instrumentImage;
-                break;
-        }
-    }
-
     public void ShowStageSelection(StagePosition newActiveStagePosition)
     {
         activeStagePosition = newActiveStagePosition;
-        
-        switch (currentShowingCarousel)
-        {
-            case Carousel.CarouselType.Musician:
-                musicianCarousel.OpenCarousel(activeStagePosition);
-                break;
-            case Carousel.CarouselType.Instrument:
-                instrumentCarousel.OpenCarousel(activeStagePosition);
-                break;
-        }
+        musicianCarousel.OpenCarousel(activeStagePosition);
+        instrumentCarousel.OpenCarousel(activeStagePosition);
+
         gameObject.SetActive(true);
         OnStageSelectionStarted?.Invoke();
     }
@@ -69,40 +43,11 @@ public class StageSelection : Singleton<StageSelection>
     {
         activeStagePosition = null;
         
+        instrumentCarousel.CloseCarousel();
+        musicianCarousel.CloseCarousel();
         gameObject.SetActive(false);
-        
-        switch (currentShowingCarousel)
-        {
-            case Carousel.CarouselType.Musician:
-                musicianCarousel.CloseCarousel();
-                break;
-            case Carousel.CarouselType.Instrument:
-                instrumentCarousel.CloseCarousel();
-                break;
-        }
-        
-        OnStageSelectionEnded?.Invoke();
-    }
 
-    public void SwapCarousels()
-    {
-        switch (currentShowingCarousel)
-        {
-            case Carousel.CarouselType.Musician:
-                currentShowingCarousel = Carousel.CarouselType.Instrument;
-                swapperImage.sprite = instrumentImage;
-                
-                musicianCarousel.CloseCarousel();
-                instrumentCarousel.OpenCarousel(activeStagePosition);
-                break;
-            case Carousel.CarouselType.Instrument:
-                currentShowingCarousel = Carousel.CarouselType.Musician;
-                swapperImage.sprite = musicianImage;
-                
-                instrumentCarousel.CloseCarousel();
-                musicianCarousel.OpenCarousel(activeStagePosition);
-                break;
-        }
+        OnStageSelectionEnded?.Invoke();
     }
 
     public List<StagePosition> GetStagePositions()

--- a/Assets/Scripts/UI/CoreGameplay/Stage/StageSelection.cs
+++ b/Assets/Scripts/UI/CoreGameplay/Stage/StageSelection.cs
@@ -107,4 +107,51 @@ public class StageSelection : Singleton<StageSelection>
     {
         return _StagePositions;
     }
+
+    public void MoveCurrentSelectionRight()
+    {
+        MoveCurrentSelection(1);
+    }
+
+    public void MoveCurrentSelectionLeft()
+    {
+        MoveCurrentSelection(-1);
+    }
+
+    private void MoveCurrentSelection(int indexDirection)
+    {
+        if (_StagePositions.Count <= 0)
+        {
+            StSDebug.LogError("StageSelection: Stage Positions were not found. How did we even get here.");
+            return;
+        }
+        
+        int currentIndex = activeStagePosition.stagePositionNumber;
+
+        // Left subtracts 1, Right adds one.
+        currentIndex += indexDirection;
+        
+        if (currentIndex < 0)
+        {
+            // Wrap to the right
+            currentIndex = _StagePositions.Count - 1;
+        }
+        else if (currentIndex >= _StagePositions.Count)
+        {
+            // Wrap to the Left
+            currentIndex = 0;
+        }
+        
+        // Simulate a "Click" on the new stage position, this will move the camera, update the carousels, and the active stage position.
+        StagePosition newPos = _StagePositions.Find(position => position.stagePositionNumber == currentIndex);
+        if (newPos)
+        {
+            newPos.OnInteract();
+        }
+        else
+        {
+            StSDebug.LogError($"StageSelection: Could not find stage position with the index '{currentIndex}'");
+        }
+        
+    }
 }

--- a/Assets/Scripts/Utils/StSCamera.cs
+++ b/Assets/Scripts/Utils/StSCamera.cs
@@ -29,6 +29,7 @@ public class StsCamera : Singleton<StsCamera>
         public float fieldOfView;
         public Vector3 focusOffset;
     }
+    
     [Header("Camera States")][Space(20)]
     [SerializeField] private List<CameraState> cameraStates;
     [SerializeField] private CameraState currentCameraState;
@@ -71,7 +72,6 @@ public class StsCamera : Singleton<StsCamera>
         }
 
         // Bind to STATIC events, doesn't matter if there is an object or not.
-        StagePosition.OnStagePositionClicked += OnStagePositionClicked;
         StageSelection.OnStageSelectionEnded += OnStageSelectionEnded;
     }
 
@@ -89,7 +89,6 @@ public class StsCamera : Singleton<StsCamera>
             onPointerDelta.canceled -= OnPointerDelta;
         }
         
-        StagePosition.OnStagePositionClicked -= OnStagePositionClicked;
         StageSelection.OnStageSelectionEnded += OnStageSelectionEnded;
     }
 
@@ -122,7 +121,7 @@ public class StsCamera : Singleton<StsCamera>
         }
     }
 
-    private void OnStagePositionClicked(StagePosition stagePosition)
+    public void OnStagePositionClicked(StagePosition stagePosition)
     {
         // Zoom onto the stage selection
         ChangeCameraState(CameraStateName.SelectedStagePosition, stagePosition.GetViewTarget());

--- a/Assets/Scripts/Utils/StSCamera.cs
+++ b/Assets/Scripts/Utils/StSCamera.cs
@@ -48,12 +48,22 @@ public class StsCamera : Singleton<StsCamera>
     [SerializeField] private float panSensitvity;
 
     private ChapterUI chapterUi;
+    private Act _act;
 
 
     private void OnEnable()
     {
         vCamTransposer = vCam.GetCinemachineComponent<CinemachineFramingTransposer>();
-        
+        _act = FindObjectOfType<Act>();
+        if (_act)
+        {
+            _act.onChapterOpen += ChapterInitialize;
+            _act.onChapterClosed += ChapterClearInitialize;
+        }
+    }
+
+    private void ChapterInitialize()
+    {
         // Subscribe to pointer events immediately, even if the game is not in a chapter.
         // They may get used later on, no harm in having the values whenever.
         input = FindObjectOfType<PlayerInput>();
@@ -75,7 +85,7 @@ public class StsCamera : Singleton<StsCamera>
         StageSelection.OnStageSelectionEnded += OnStageSelectionEnded;
     }
 
-    private void OnDisable()
+    private void ChapterClearInitialize()
     {
         if (onPointerPress != null)
         {
@@ -90,6 +100,17 @@ public class StsCamera : Singleton<StsCamera>
         }
         
         StageSelection.OnStageSelectionEnded += OnStageSelectionEnded;
+    }
+
+    private void OnDisable()
+    {
+        ChapterClearInitialize();
+        
+        if (_act)
+        {
+            _act.onChapterOpen -= ChapterInitialize;
+            _act.onChapterClosed -= ChapterClearInitialize;
+        }
     }
 
     private void Update()


### PR DESCRIPTION
closes #90 
progress #74 

- Stage Selection can now swap between positions with arrows on the left and right.
- Can no longer click on other stage positions to swap to them.
- Stage Selection now shows both Musician and Instrument carousels.

Testing:
1. Start in Act 1
2. Enter Chapter 
3. Click Intro to advance to Stage Selection
4. Click on a Stage Position
5. Both carousels should show, and the camera zooms in.
6. Clicking a stage position does nothing
7. Clicking the Left/Right button changes the stage position to the left or right, with wrapping.