### PR TITLE
Fix/issues/116

### DIFF
--- a/Assets/Scripts/GameStructure/Act.cs
+++ b/Assets/Scripts/GameStructure/Act.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using GameStructure;
 using GameStructure.Narrative;
 using UnityEngine;
 using Utils;
@@ -109,8 +108,8 @@ public class Act : MonoBehaviour
         {
             if (SceneLoader.Instance.LoadScene(chapters[currentChapterIndex].sceneInfo))
             {
-                onChapterOpen?.Invoke();
                 SceneLoader.Instance.onSceneOpened += ChapterLoaded;
+                onChapterOpen?.Invoke();
             }
         }
         else

--- a/Assets/Scripts/GameStructure/Act.cs
+++ b/Assets/Scripts/GameStructure/Act.cs
@@ -39,8 +39,8 @@ public class Act : MonoBehaviour
     public event Action onChapterClosed;
     public event Action onCutsceneComplete;
     public event Action OnActComplete;
-    
-    void Awake()
+
+    private void Awake()
     {
         if (!actCanvas)
         {
@@ -51,7 +51,7 @@ public class Act : MonoBehaviour
 
     }
 
-    void Start()
+    private void Start()
     {
         HandleIntroCutScene();
         CheckIfActIsComplete();
@@ -191,15 +191,15 @@ public class Act : MonoBehaviour
         actCanvas.SetEnabled(true);
         onCutsceneComplete?.Invoke();
     }
-    
 
-    void GoToNextAct()
+
+    private void GoToNextAct()
     {
         onCutsceneComplete -= GoToNextAct;
         SceneLoader.Instance.LoadScene($"Act {actNumber + 1}");
     }
 
-    void CloseChapter()
+    private void CloseChapter()
     {
         //Close the chapter and clear the current chapter
         SceneLoader.Instance.CloseScene(chapters[currentChapterIndex].sceneInfo);

--- a/Assets/Scripts/GameStructure/ActCanvas.cs
+++ b/Assets/Scripts/GameStructure/ActCanvas.cs
@@ -32,12 +32,7 @@ public class ActCanvas : MonoBehaviour
     
     private void OnDisable()
     {
-        if (_act)
-        {
-            _act.onChapterOpen -= ChapterOpened;
-            _act.onChapterClosed -= ChapterClosed;
-            _act.OnActComplete -= ShowNextActButton;
-        }
+        UnhookAllEventBindings();
     }
 
     private void OnEnable()
@@ -66,11 +61,24 @@ public class ActCanvas : MonoBehaviour
     {
         if (_act)
         {
+            UnhookAllEventBindings();
+
             _act.onChapterOpen += ChapterOpened;
             _act.onChapterClosed += ChapterClosed;
             _act.OnActComplete += ShowNextActButton;
             actTitle.text = $"Act {_act.GetActNumber()}";
         }
+    }
+
+    private void UnhookAllEventBindings()
+    {
+        if (_act == null)
+        {
+            return;
+        }
+        _act.onChapterOpen -= ChapterOpened;
+        _act.onChapterClosed -= ChapterClosed;
+        _act.OnActComplete -= ShowNextActButton;
     }
 
 

--- a/Assets/Scripts/GameStructure/Chapter.cs
+++ b/Assets/Scripts/GameStructure/Chapter.cs
@@ -208,7 +208,7 @@ public class Chapter : Singleton<Chapter>
         return false;
     }
 
-    void OnPerformanceComplete(float newStarsEarned)
+    private void OnPerformanceComplete(float newStarsEarned)
     {
         starsEarned = newStarsEarned;
         

--- a/Assets/Scripts/GameStructure/Chapter.cs
+++ b/Assets/Scripts/GameStructure/Chapter.cs
@@ -126,7 +126,7 @@ public class Chapter : Singleton<Chapter>
 
     public void ReturnMusician(Musician musician)
     {
-        if (musician is not null && !availableMusicians.Contains(musician))
+        if (musician != null && !availableMusicians.Contains(musician))
         {
             availableMusicians.Add(musician);
             availableMusicians.Sort();
@@ -146,7 +146,7 @@ public class Chapter : Singleton<Chapter>
 
     public void ReturnInstrument(Instrument instrument)
     {
-        if (instrument is not null && !availableInstruments.Contains(instrument))
+        if (instrument != null && !availableInstruments.Contains(instrument))
         {
             availableInstruments.Add(instrument);
             availableInstruments.Sort();
@@ -155,7 +155,7 @@ public class Chapter : Singleton<Chapter>
 
     public void ReturnObject(StSObject returningObject)
     {
-        if (returningObject is null)
+        if (returningObject == null)
         {
             return;
         }
@@ -183,7 +183,7 @@ public class Chapter : Singleton<Chapter>
 
     public bool ConsumeObject(StSObject objectToConsume)
     {
-        if (objectToConsume is null)
+        if (objectToConsume == null)
         {
             return false;
         }

--- a/Assets/Scripts/GameStructure/ChapterUI.cs
+++ b/Assets/Scripts/GameStructure/ChapterUI.cs
@@ -155,7 +155,7 @@ public class ChapterUI : MonoBehaviour
         List<RaycastResult> results = new List<RaycastResult>();
         
         //Ray cast UI elements only.
-        _graphicRaycaster.Raycast(pointerData, results);
+        _graphicRaycaster?.Raycast(pointerData, results);
 
         return results.Count > 0;
     }

--- a/Assets/Scripts/GameStructure/ChapterUI.cs
+++ b/Assets/Scripts/GameStructure/ChapterUI.cs
@@ -67,16 +67,16 @@ public class ChapterUI : MonoBehaviour
         StagePosition.OnStagePositionChanged -= OnStagePositionChanged;
         StageSelection.OnStageSelectionFocusChanged -= StagePositionFocusChanged;
         Chapter.onRevealRating -= RevealRating;
-        
-        if (onPointerPosition != null)
-        {
-            onPointerPosition.performed -= OnPointerPosition;
-        }
     }
 
     private void OnDisable()
     {
         UnhookAllEventBindings();
+        
+        if (onPointerPosition != null)
+        {
+            onPointerPosition.performed -= OnPointerPosition;
+        }
     }
 
     private void OnStageChanged(Chapter.ChapterStage chapterStage)
@@ -162,6 +162,4 @@ public class ChapterUI : MonoBehaviour
 
         return results.Count > 0;
     }
-    
-    
 }

--- a/Assets/Scripts/GameStructure/ChapterUI.cs
+++ b/Assets/Scripts/GameStructure/ChapterUI.cs
@@ -51,29 +51,32 @@ public class ChapterUI : MonoBehaviour
 
     private void OnEnable()
     {
+        UnhookAllEventBindings();
+
         Chapter.onStageChanged += OnStageChanged;
         StagePosition.OnStagePositionClicked += OnStagePositionClicked;
         StagePosition.OnStagePositionChanged += OnStagePositionChanged;
         StageSelection.OnStageSelectionFocusChanged += StagePositionFocusChanged;
         Chapter.onRevealRating += RevealRating;
     }
-    
-    private void OnDisable()
+
+    private void UnhookAllEventBindings()
     {
-        if (Chapter is not null)
-        {
-            Chapter.onRevealRating -= RevealRating;
-            Chapter.onStageChanged -= OnStageChanged;
-        }
-        
-        if (onPointerPosition is not null)
-        {
-            onPointerPosition.performed -= OnPointerPosition;
-        }
-        
+        Chapter.onStageChanged -= OnStageChanged;
         StagePosition.OnStagePositionClicked -= OnStagePositionClicked;
         StagePosition.OnStagePositionChanged -= OnStagePositionChanged;
         StageSelection.OnStageSelectionFocusChanged -= StagePositionFocusChanged;
+        Chapter.onRevealRating -= RevealRating;
+        
+        if (onPointerPosition != null)
+        {
+            onPointerPosition.performed -= OnPointerPosition;
+        }
+    }
+
+    private void OnDisable()
+    {
+        UnhookAllEventBindings();
     }
 
     private void OnStageChanged(Chapter.ChapterStage chapterStage)

--- a/Assets/Scripts/Managers/SceneLoader.cs
+++ b/Assets/Scripts/Managers/SceneLoader.cs
@@ -42,7 +42,7 @@ public class SceneLoader : Singleton<SceneLoader>
     /// <param name="sceneToLoad">The scene that you want to load</param>
     public bool LoadScene(SceneStruct sceneToLoad)
     {
-        if (sceneToLoad.sceneToLoad is not null)
+        if (sceneToLoad.sceneToLoad != null)
         {
             StSDebug.Log($"Open Scene: {sceneToLoad.sceneDisplayName}");
             
@@ -108,6 +108,6 @@ public class SceneLoader : Singleton<SceneLoader>
 
     public bool CanLoadScene(string sceneString)
     {
-        return GetSceneStructByString(sceneString).sceneToLoad is not null;
+        return GetSceneStructByString(sceneString).sceneToLoad != null;
     }
 }

--- a/Assets/Scripts/UI/CoreGameplay/Stage/StagePosition.cs
+++ b/Assets/Scripts/UI/CoreGameplay/Stage/StagePosition.cs
@@ -57,12 +57,12 @@ public class StagePosition : MonoBehaviour
 
     public bool IsMusicianOccupied()
     {
-        return musicianOccupied is not null;
+        return musicianOccupied != null;
     }
     
     public bool IsInstrumentOccupied()
     {
-        return instrumentOccupied is not null;
+        return instrumentOccupied != null;
     }
 
     public InstrumentProficiency GetMusicianProficiency()

--- a/Assets/Scripts/UI/CoreGameplay/Stage/StageSelection.cs
+++ b/Assets/Scripts/UI/CoreGameplay/Stage/StageSelection.cs
@@ -119,6 +119,6 @@ public class StageSelection : Singleton<StageSelection>
 
     public bool HasActiveSelection()
     {
-        return activeStagePosition is not null;
+        return activeStagePosition != null;
     }
 }

--- a/Assets/Scripts/UI/CoreGameplay/Stage/StageSelection.cs
+++ b/Assets/Scripts/UI/CoreGameplay/Stage/StageSelection.cs
@@ -46,7 +46,7 @@ public class StageSelection : Singleton<StageSelection>
     
     public void HideStageSelection()
     {
-        activeStagePosition.OnFocusEnd();
+        activeStagePosition?.OnFocusEnd();
         
         activeStagePosition = null;
         

--- a/Assets/Scripts/UI/MusicianInfoPanel.cs
+++ b/Assets/Scripts/UI/MusicianInfoPanel.cs
@@ -13,6 +13,11 @@ public class MusicianInfoPanel : MonoBehaviour
     {
         StagePosition.OnStagePositionChanged += OnStagePositionChanged;
     }
+    
+    private void OnDisable()
+    {
+        StagePosition.OnStagePositionChanged -= OnStagePositionChanged;
+    }
 
     private void OnStagePositionChanged(StagePosition stagePosition)
     {

--- a/Assets/Scripts/Utils/StSCamera.cs
+++ b/Assets/Scripts/Utils/StSCamera.cs
@@ -66,6 +66,9 @@ public class StsCamera : Singleton<StsCamera>
 
     private void ChapterInitialize()
     {
+        currentCameraState.focusTarget = null;
+        ChangeCameraState(CameraStateName.Default);
+        
         // Subscribe to pointer events immediately, even if the game is not in a chapter.
         // They may get used later on, no harm in having the values whenever.
         input = FindObjectOfType<PlayerInput>();

--- a/Assets/Scripts/Utils/StSCamera.cs
+++ b/Assets/Scripts/Utils/StSCamera.cs
@@ -66,9 +66,8 @@ public class StsCamera : Singleton<StsCamera>
 
     private void ChapterInitialize()
     {
-        currentCameraState.focusTarget = null;
-        ChangeCameraState(CameraStateName.Default);
-        
+        ResetCanvasAndCameraState();
+
         // Subscribe to pointer events immediately, even if the game is not in a chapter.
         // They may get used later on, no harm in having the values whenever.
         input = FindObjectOfType<PlayerInput>();
@@ -90,6 +89,13 @@ public class StsCamera : Singleton<StsCamera>
         StageSelection.OnStageSelectionEnded += OnStageSelectionEnded;
     }
 
+    private void ResetCanvasAndCameraState()
+    {
+        currentCameraState.focusTarget = null;
+        ChangeCameraState(CameraStateName.Default);
+        chapterUi = null;
+    }
+
     private void ChapterClearInitialize()
     {
         if (onPointerPress != null)
@@ -104,6 +110,7 @@ public class StsCamera : Singleton<StsCamera>
             onPointerDelta.canceled -= OnPointerDelta;
         }
         
+        StageSelection.OnStageSelectionEnded -= OnStageSelectionEnded;
         StageSelection.OnStageSelectionEnded += OnStageSelectionEnded;
     }
 
@@ -183,7 +190,12 @@ public class StsCamera : Singleton<StsCamera>
         // Wait until the end of the frame to ensure that the Pointer Position has been able to update.
         // Solves an issue where the pointer down would happen before the pointer position and there would be invalid coordinates.
         yield return new WaitForEndOfFrame();
-        IsMovingCamera = !chapterUi.IsPointerOverUi();
+
+        if (chapterUi != null)
+        {
+            IsMovingCamera = !chapterUi.IsPointerOverUi();
+        }
+
         yield return null;
     }
 

--- a/Assets/Scripts/Utils/StSCamera.cs
+++ b/Assets/Scripts/Utils/StSCamera.cs
@@ -93,7 +93,6 @@ public class StsCamera : Singleton<StsCamera>
     {
         currentCameraState.focusTarget = null;
         ChangeCameraState(CameraStateName.Default);
-        chapterUi = null;
     }
 
     private void ChapterClearInitialize()
@@ -171,12 +170,12 @@ public class StsCamera : Singleton<StsCamera>
 
     private void OnPointerDown(InputAction.CallbackContext context)
     {
-        if (chapterUi is null)
+        if (chapterUi == null)
         {
             chapterUi = FindObjectOfType<ChapterUI>();
         }
 
-        if (chapterUi is null)
+        if (chapterUi == null)
         {
             StSDebug.LogWarning("No chapter Ui found in camera system when checking for if the pointer is over the Ui.");
             return;


### PR DESCRIPTION
This PR fixes a ton of things and also closes #116
- x == null checks are safer for objects that are references by IL code  or MonoBehaviours since it also check unity lifetime
- Unbinding an event before binding it for high traffic instantiated objects is safe and will not throw errors
- OnDisable should always unbind all static event references - no exceptions
- Camera now auto focuses on nothing at the start of every chapter 