### PR TITLE
Tweak: Force analytics to be on for early access

### DIFF
--- a/Assets/Scripts/Analytics/AnalyticsHandlerBase.cs
+++ b/Assets/Scripts/Analytics/AnalyticsHandlerBase.cs
@@ -22,7 +22,8 @@ namespace Analytics
         protected virtual void OnEnable() {
             if (PlayerPrefs.HasKey(CONSENT_PREFS_KEY))
             {
-                switch (PlayerPrefs.GetInt(CONSENT_PREFS_KEY))
+                // TODO During early-access, we're forcing analytics usage. Restore normal behavior after leaving early-access.
+                switch (1) // switch (PlayerPrefs.GetInt(CONSENT_PREFS_KEY)
                 {
                     case -1: // Player has explicitly opted-out.
                         OptOut();

--- a/Assets/Scripts/UI/CoreGameplay/Stage/StagePosition.cs
+++ b/Assets/Scripts/UI/CoreGameplay/Stage/StagePosition.cs
@@ -181,6 +181,7 @@ public class StagePosition : MonoBehaviour
     {
         // We only want this to occur once per set of changes
         if (_hasUncommittedChanges && musicianOccupied && instrumentOccupied)
+        {
             OnStagePositionCommitted?.Invoke(this);
             _hasUncommittedChanges = false;
         }


### PR DESCRIPTION
Add an override to the analytics opt-in system to always automatically opt-in at game start. We'll revert this after the vertical slice ends.